### PR TITLE
use var for path, add permissions to downloaded file

### DIFF
--- a/UpdateYuzu.sh
+++ b/UpdateYuzu.sh
@@ -1,3 +1,8 @@
 #! /bin/bash
-curl -s https://api.github.com/repos/pineappleEA/pineapple-src/releases/latest | jq -r ".assets[0] | .browser_download_url" | wget -qO /path/to/yuzu.AppImage -i -
-/path/to/yuzu.AppImage
+YUZU_PATH=/home/deck/Applications/yuzu.AppImage
+# Download latest Yuzu EA
+curl -s https://api.github.com/repos/pineappleEA/pineapple-src/releases/latest | jq -r ".assets[0] | .browser_download_url" | wget -qO $YUZU_PATH -i -
+# Give it executable permissions
+chmod +x $YUZU_PATH
+# Launch Yuzu
+$YUZU_PATH


### PR DESCRIPTION
Was getting some "permission denied" errors from the script because the freshly downloaded Yuzu didn't have permission to be run as an executable.

I also extracted the Yuzu download location to a variable so it only has to be to declared once, and I changed its value to the default location that Emudeck installs Yuzu.